### PR TITLE
Fix overlapping area calculation

### DIFF
--- a/KDDragAndDropCollectionViews/KDDragAndDropManager.swift
+++ b/KDDragAndDropCollectionViews/KDDragAndDropManager.swift
@@ -150,7 +150,7 @@ class KDDragAndDropManager: NSObject, UIGestureRecognizerDelegate {
                     
                     if (intersectionNew.width * intersectionNew.height) > overlappingArea {
                         
-                        overlappingArea = intersectionNew.width * intersectionNew.width
+                        overlappingArea = intersectionNew.width * intersectionNew.height
                         
                         mainOverView = view
                     }


### PR DESCRIPTION
When calculating overlapping area, the width of the intersection should be multiplied by the height of the intersection rather than squaring the width.