### PR TITLE
Added can drag cell at index path datasource method

### DIFF
--- a/Classes/KDDragAndDropCollectionView.swift
+++ b/Classes/KDDragAndDropCollectionView.swift
@@ -32,7 +32,7 @@ public protocol KDDragAndDropCollectionViewDataSource : UICollectionViewDataSour
     func collectionView(_ collectionView: UICollectionView, moveDataItemFromIndexPath from: IndexPath, toIndexPath to : IndexPath) -> Void
     func collectionView(_ collectionView: UICollectionView, insertDataItem dataItem : AnyObject, atIndexPath indexPath: IndexPath) -> Void
     func collectionView(_ collectionView: UICollectionView, deleteDataItemAtIndexPath indexPath: IndexPath) -> Void
-    
+    func collectionView(_ collectionView: UICollectionView, cellIsDraggableAtIndexPath indexPath: IndexPath) -> Bool
 }
 
 public class KDDragAndDropCollectionView: UICollectionView, KDDraggable, KDDroppable {
@@ -58,12 +58,12 @@ public class KDDragAndDropCollectionView: UICollectionView, KDDraggable, KDDropp
 
     // MARK : KDDraggable
     public func canDragAtPoint(_ point : CGPoint) -> Bool {
-        
-        if self.dataSource is KDDragAndDropCollectionViewDataSource {
-            return self.indexPathForItem(at: point) != nil
+        if let dataSource = self.dataSource as? KDDragAndDropCollectionViewDataSource,
+        let indexPathOfPoint = self.indexPathForItem(at: point) {
+            return dataSource.collectionView(self, cellIsDraggableAtIndexPath: indexPathOfPoint)
         }
+
         return false
-        
     }
     
     public func representationImageAtPoint(_ point : CGPoint) -> UIView? {

--- a/KDDragAndDropCollectionViews/ViewController.swift
+++ b/KDDragAndDropCollectionViews/ViewController.swift
@@ -54,7 +54,6 @@ extension UIColor {
 let colours = [UIColor.kdBrown, UIColor.kdGreen, UIColor.kdBlue]
 
 class ViewController: UIViewController, KDDragAndDropCollectionViewDataSource {
-
     @IBOutlet weak var firstCollectionView: KDDragAndDropCollectionView!
     @IBOutlet weak var secondCollectionView: KDDragAndDropCollectionView!
     @IBOutlet weak var thirdCollectionView: KDDragAndDropCollectionView!
@@ -149,6 +148,9 @@ class ViewController: UIViewController, KDDragAndDropCollectionViewDataSource {
         
     }
 
+    func collectionView(_ collectionView: UICollectionView, cellIsDraggableAtIndexPath indexPath: IndexPath) -> Bool {
+        return indexPath.row % 2 == 0
+    }
 }
 
 


### PR DESCRIPTION
Something like this if you wanted every other cell to be draggable. Implemented this way in the test app.

```swift
func collectionView(_ collectionView: UICollectionView, cellIsDraggableAtIndexPath indexPath: IndexPath) -> Bool {
    return indexPath.row % 2 == 0
}
```